### PR TITLE
suggestions: JSX typescript deprecation error + MainPages as name type?

### DIFF
--- a/src/components/sidebar/PageButton.tsx
+++ b/src/components/sidebar/PageButton.tsx
@@ -21,7 +21,6 @@ export default function PageButton({
   setHoveredButton,
 }: PageButtonProps) {
   const currentPath = usePathname();
-
   const buttonStyles = `${
     isOpen ? "w-[14.375rem] flex justify-start pl-6" : "w-[3.125rem]"
   } h-[3.125rem] text-base-300 capitalize border-none hover:bg-base-100`;
@@ -37,7 +36,7 @@ export default function PageButton({
 
   return (
     <li>
-      <Link href={element.name !== String(MainPages.myVoyage) ? link : ""}>
+      <Link href={element.name !== MainPages.myVoyage ? link : ""}>
         <Button
           title={element.name}
           customClassName={`${buttonStyles} ${getButtonBackgroundStyle(

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import type React from "react";
 import { usePathname } from "next/navigation";
 import {
   RectangleGroupIcon,
@@ -11,18 +12,6 @@ import {
 import PageButton from "./PageButton";
 import VoyagePageButton from "./VoyagePageButton";
 import ExpandButton from "./ExpandButton";
-
-export type PageProperty = {
-  name: string;
-  marginBottom: string;
-  icon: JSX.Element;
-  link: string;
-};
-
-export type VoyagePageProperty = {
-  name: string;
-  link: string;
-};
 
 export enum MainPages {
   dashboard = "Dashboard",
@@ -39,6 +28,18 @@ export enum VoyagePages {
   sprints = "Sprints",
   resources = "Resources",
 }
+
+export type VoyagePageProperty = {
+  name: string;
+  link: string;
+};
+
+export type PageProperty = {
+  name: MainPages;
+  marginBottom: string;
+  icon: React.JSX.Element;
+  link: string;
+};
 
 export const voyagePages: VoyagePageProperty[] = [
   {
@@ -109,7 +110,7 @@ export default function Sidebar() {
     if (typeof element === "string") {
       setSelectedButton(element);
       setIsOpenSidebar(false);
-    } else if ((element.name as MainPages) === MainPages.myVoyage) {
+    } else if (element.name === MainPages.myVoyage) {
       setIsOpenSidebar(true);
     } else {
       setSelectedButton(element.link);


### PR DESCRIPTION
Just some TS suggestions related to the sidebar in gerneral, the linter was telling the use of `JSX` is now deprecated and should be prefixed with `React`.  PageProperty.name going to always be a value from the Enum MainPages? If so we could give it greater specificity to and instead of setting it as a string and having to assert the type as `as MainPages` later we can just give it the type `MainPages` or even give it a union of types if it is likely to have another type.