### PR TITLE
set up production url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env*.production
 .env
 
 # vercel

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    webpack(config, { buildId, dev, isServer, defaultLoaders, webpack }) {
+        console.log(`Running in ${process.env.NODE_ENV} mode`)
+        return config;
+    },
     images: {
         remotePatterns: [
             {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "prod": "next build && next start",
     "lint": "next lint",
     "prettier": "prettier . --write",
     "test": "jest",


### PR DESCRIPTION
# Description

I've created a .env.production file and set the url. NextJS is able to automatically know which .env file to use environment variable in.

If you are testing production environment in your own local server, please change file name from .env to .env.local so that NextJS has a way to differentiate between development and production

## Issue link

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually
I created a console log on next.config.js so that when we run the scripts, we're able to see whether its running on development or production mode.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules